### PR TITLE
Add option to use stock boosters and setting to force using it

### DIFF
--- a/localization/localization_en.json
+++ b/localization/localization_en.json
@@ -65,10 +65,12 @@
     "response_msg": "You earned {amount} Pokémon Dollars"
   },
   "booster_cmd": {
-    "title": "Booster"
+    "title": "Booster",
+    "no_boosters_in_stock": "You have no boosters in stock"
   },
   "promo_booster_cmd": {
-    "title": "Promo Booster"
+    "title": "Promo Booster",
+    "no_boosters_in_stock": "You have no promo boosters in stock"
   },
   "market_booster_cmd": {
     "title": "Booster Market"

--- a/localization/localization_en.json
+++ b/localization/localization_en.json
@@ -46,6 +46,9 @@
     "booster_opening_with_image_field_name": "Booster opened with card images by default",
     "language_changed_response_msg": "Language changed to:",
     "booster_opening_with_image_response_msg": "Booster opening mode switched",
+    "booster_stock_use_field_name": "Only use stock boosters when called with option",
+    "booster_stock_use_response_msg": "Booster stock use changed",
+    "booster_stock_use_label": "Require option to use booster stock",
     "select_language_placeholder": "Change language",
     "switch_booster_opening_label": "Switch booster opening value"
   },

--- a/localization/localization_fr.json
+++ b/localization/localization_fr.json
@@ -65,10 +65,12 @@
     "response_msg": "Vous récupérez {amount} Pokédollars"
   },
   "booster_cmd": {
-    "title": "Booster"
+    "title": "Booster",
+    "no_boosters_in_stock": "Vous n'avez aucun booster en stock."
   },
   "promo_booster_cmd": {
-    "title": "Booster Promo"
+    "title": "Booster Promo",
+    "no_boosters_in_stock": "Vous n'avez aucun booster promo en stock."
   },
   "market_booster_cmd": {
     "title": "Échoppe à Boosters"

--- a/localization/localization_fr.json
+++ b/localization/localization_fr.json
@@ -45,6 +45,9 @@
     "language_field_name": "Langue",
     "booster_opening_with_image_field_name": "Image des cartes affichées lors de l'ouverture d'un booster",
     "booster_opening_with_image_response_msg": "Mode d'ouverture d'un booster changé",
+    "booster_stock_use_field_name": "Toujours besoin de l'option pour utiliser les boosters du stock",
+    "booster_stock_use_response_msg": "Option d'utilisation des boosters du stock changée",
+    "booster_stock_use_label": "Besoin de l'option pour utiliser le stock",
     "language_changed_response_msg": "Nouvelle langue configurée :",
     "select_language_placeholder": "Changer la langue",
     "switch_booster_opening_label": "Changer le mode d'ouverture d'un booster"

--- a/src/commands/booster_command.py
+++ b/src/commands/booster_command.py
@@ -158,13 +158,16 @@ class BoosterCog(commands.Cog):
         return paginated_embed
 
     @app_commands.command(name="booster", description="Open a basic booster")
-    async def booster_command(self, interaction: discord.Interaction, with_image: Optional[bool] = None) -> None:
+    async def booster_command(self, interaction: discord.Interaction, with_image: Optional[bool] = None, use_booster_stock: Optional[bool] = False) -> None:
         user = self.user_service.get_and_update_user(interaction.user)
         user_language_id = user.settings.language_id
 
-        if user.cooldowns.timestamp_for_next_basic_booster > time.time():
+        if use_booster_stock or user.cooldowns.timestamp_for_next_basic_booster > time.time():
             if user.boosters_quantity > 0:
                 self.user_service.consume_booster(user.id, "Basic")
+            elif use_booster_stock:
+                await interaction.response.send_message(self.t(user_language_id, 'booster_cmd.no_boosters_in_stock'))
+                return
             else:
                 discord_formatted_timestamp = discord_tools.timestamp_to_relative_time_format(
                     user.cooldowns.timestamp_for_next_basic_booster)
@@ -203,13 +206,16 @@ class BoosterCog(commands.Cog):
             await interaction.response.send_message(embed=embed)
 
     @app_commands.command(name="promo_booster", description="Open a Promo booster")
-    async def promo_booster_command(self, interaction: discord.Interaction, with_image: Optional[bool] = None) -> None:
+    async def promo_booster_command(self, interaction: discord.Interaction, with_image: Optional[bool] = None, use_booster_stock: Optional[bool] = False) -> None:
         user = self.user_service.get_and_update_user(interaction.user)
         user_language_id = user.settings.language_id
 
-        if user.cooldowns.timestamp_for_next_promo_booster > time.time():
+        if use_booster_stock or user.cooldowns.timestamp_for_next_promo_booster > time.time():
             if user.promo_boosters_quantity > 0:
                 self.user_service.consume_booster(user.id, "Promo")
+            elif use_booster_stock:
+                await interaction.response.send_message(self.t(user_language_id, 'promo_booster_cmd.no_boosters_in_stock'))
+                return
             else:
                 discord_formatted_timestamp = discord_tools.timestamp_to_relative_time_format(
                     user.cooldowns.timestamp_for_next_promo_booster)

--- a/src/commands/booster_command.py
+++ b/src/commands/booster_command.py
@@ -163,7 +163,7 @@ class BoosterCog(commands.Cog):
         user_language_id = user.settings.language_id
 
         if use_booster_stock or user.cooldowns.timestamp_for_next_basic_booster > time.time():
-            if user.boosters_quantity > 0:
+            if user.boosters_quantity > 0 and ((not user.settings.only_use_booster_stock_with_option) or use_booster_stock):
                 self.user_service.consume_booster(user.id, "Basic")
             elif use_booster_stock:
                 await interaction.response.send_message(self.t(user_language_id, 'booster_cmd.no_boosters_in_stock'))
@@ -211,7 +211,7 @@ class BoosterCog(commands.Cog):
         user_language_id = user.settings.language_id
 
         if use_booster_stock or user.cooldowns.timestamp_for_next_promo_booster > time.time():
-            if user.promo_boosters_quantity > 0:
+            if user.promo_boosters_quantity > 0 and ((not user.settings.only_use_booster_stock_with_option) or use_booster_stock):
                 self.user_service.consume_booster(user.id, "Promo")
             elif use_booster_stock:
                 await interaction.response.send_message(self.t(user_language_id, 'promo_booster_cmd.no_boosters_in_stock'))

--- a/src/entities/user_settings_entity.py
+++ b/src/entities/user_settings_entity.py
@@ -1,8 +1,10 @@
 class UserSettingsEntity:
-    def __init__(self, language_id: int = 0, booster_opening_with_image: bool = True):
+    def __init__(self, language_id: int = 0, booster_opening_with_image: bool = True, only_use_booster_stock_with_option: bool = True):
         self.language_id = language_id
         self.booster_opening_with_image = booster_opening_with_image
+        self.only_use_booster_stock_with_option = only_use_booster_stock_with_option
 
     def __setstate__(self, state):
         self.language_id = state.get("language_id", 0)
         self.booster_opening_with_image = state.get("booster_opening_with_image", True)
+        self.only_use_booster_stock_with_option = state.get("only_use_booster_stock_with_option", False)

--- a/src/repositories/in_memory_user_repository.py
+++ b/src/repositories/in_memory_user_repository.py
@@ -51,6 +51,10 @@ class InMemoryUserRepository(UserRepository):
         # TODO: implementation
         pass
 
+    def change_only_use_booster_stock_with_option(self, user_id, new_only_use_booster_stock_with_option_value):
+        # TODO: implementation
+        pass
+
     def change_basic_booster_cooldown(self, user_id: int, updated_timestamp_for_cooldown: int) -> bool:
         # TODO: implementation
         pass

--- a/src/repositories/pickle_file_user_repository.py
+++ b/src/repositories/pickle_file_user_repository.py
@@ -97,6 +97,14 @@ class PickleFileUserRepository(UserRepository):
             return True
         return False
 
+    def change_only_use_booster_stock_with_option(self, user_id, new_only_use_booster_stock_with_option_value):
+        users_by_id = PickleFileUserRepository._load_pickle_file()
+        if user_id in users_by_id:
+            users_by_id[user_id].settings.only_use_booster_stock_with_option = new_only_use_booster_stock_with_option_value
+            PickleFileUserRepository._save_pickle_file(users_by_id)
+            return True
+        return False
+
     def change_basic_booster_cooldown(self, user_id: int, updated_timestamp_for_cooldown: int) -> bool:
         users_by_id = PickleFileUserRepository._load_pickle_file()
         if user_id in users_by_id:

--- a/src/repositories/user_repository.py
+++ b/src/repositories/user_repository.py
@@ -47,6 +47,10 @@ class UserRepository(ABC):
         pass
 
     @abstractmethod
+    def change_only_use_booster_stock_with_option(self, user_id, new_only_use_booster_stock_with_option_value):
+        pass
+
+    @abstractmethod
     def change_basic_booster_cooldown(self, user_id: int, updated_timestamp_for_cooldown: int) -> bool:
         pass
 

--- a/src/services/settings_service.py
+++ b/src/services/settings_service.py
@@ -32,3 +32,6 @@ class SettingsService:
     def update_booster_opening_with_image(self, user_id: int, new_booster_opening_with_image_value: bool):
         self._user_repository.change_booster_opening_with_image_by_default(user_id,
                                                                            new_booster_opening_with_image_value)
+
+    def update_only_use_booster_stock_with_option(self, user_id: int, new_only_use_booster_stock_with_option_value: bool):
+        self._user_repository.change_only_use_booster_stock_with_option(user_id, new_only_use_booster_stock_with_option_value)


### PR DESCRIPTION
* Add option in `/booster` and `/promo_booster` to prioritize opening boosters from the user's stock to free boosters
* Add setting to require that option when opening boosters from the stock to minimize confusion when opening stock boosters after free boosters
Closes #48 